### PR TITLE
Move offhand Spellbooks to the left to prevent crosshair overlap

### DIFF
--- a/common/src/main/java/com/ssblur/scriptor/item/Spellbook.java
+++ b/common/src/main/java/com/ssblur/scriptor/item/Spellbook.java
@@ -175,7 +175,7 @@ public class Spellbook extends Item implements ItemWithCustomRenderer {
         matrix.popPose();
       }
     } else {
-      matrix.translate(0.40f, 0.0f, 0);
+      matrix.translate(0.31f, 0.0f, 0);
       {
         matrix.pushPose(); // Left hand, left page
 

--- a/common/src/main/resources/assets/scriptor/models/item/spellbook.json
+++ b/common/src/main/resources/assets/scriptor/models/item/spellbook.json
@@ -81,7 +81,7 @@
 		},
 		"firstperson_lefthand": {
 			"rotation": [40, 0, 0],
-			"translation": [-3, 1, 0]
+			"translation": [-1.5, 1, 0]
 		},
 		"ground": {
 			"scale": [0.6, 0.6, 0.6]


### PR DESCRIPTION
Only observed overlap was while moving with bobbing turned on and pulling the mouse to the right. Should be fine.