### PR TITLE
Fix issue with Serializer breaking on top of words

### DIFF
--- a/common/src/main/java/com/ssblur/scriptor/helpers/LimitedBookSerializer.java
+++ b/common/src/main/java/com/ssblur/scriptor/helpers/LimitedBookSerializer.java
@@ -54,17 +54,33 @@ public class LimitedBookSerializer {
   public static ListTag encodeText(String text) {
     Gson gson = new Gson();
     List<Page> list = new ArrayList<>();
-    int index = 0;
-    int max;
-    while(index < text.length()) {
-      max = Integer.min(index + 96, text.length());
-      list.add(new Page(text.substring(index, max)));
-      index += 96;
+    String[] tokens = text.split("\\s+");
+
+    int pageLength = 0;
+    StringBuilder page = new StringBuilder();
+    for(var token: tokens) {
+      if(token.length() >= 96) {
+        pageLength = 0;
+        list.add(new Page(page.toString()));
+        list.add(new Page(token));
+        page = new StringBuilder();
+      } else if((token.length() + page.length()) >= 96) {
+        pageLength = token.length();
+        list.add(new Page(page.toString()));
+        page = new StringBuilder();
+        page.append(token);
+        page.append(" ");
+      } else {
+        pageLength += token.length();
+        page.append(token);
+        page.append(" ");
+      }
     }
+    if(!page.isEmpty()) list.add(new Page(page.toString()));
 
     ListTag tag = new ListTag();
-    for(Page page: list)
-      tag.add(StringTag.valueOf(gson.toJson(page)));
+    for(Page p: list)
+      tag.add(StringTag.valueOf(gson.toJson(p)));
 
     return tag;
   }

--- a/common/src/main/java/com/ssblur/scriptor/item/IdentifyScroll.java
+++ b/common/src/main/java/com/ssblur/scriptor/item/IdentifyScroll.java
@@ -1,6 +1,8 @@
 package com.ssblur.scriptor.item;
 
 import com.ssblur.scriptor.messages.IdentifyNetwork;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
@@ -19,6 +21,7 @@ public class IdentifyScroll extends Item {
     super(properties);
   }
 
+  @Environment(EnvType.CLIENT)
   public boolean overrideStackedOnOther(ItemStack itemStack, Slot slot, ClickAction clickAction, Player player) {
     if(clickAction == ClickAction.SECONDARY && !slot.getItem().isEmpty() && slot.getItem().getItem() instanceof Spellbook) {
       if(player.getCooldowns().isOnCooldown(this)) return true;

--- a/common/src/main/java/com/ssblur/scriptor/word/action/BreakBlockAction.java
+++ b/common/src/main/java/com/ssblur/scriptor/word/action/BreakBlockAction.java
@@ -57,7 +57,7 @@ public class BreakBlockAction extends Action {
       if(caster instanceof EntityTargetable entityTargetable) {
         if(entityTargetable.getTargetEntity() instanceof Player player)
           state.getBlock().playerDestroy(level, player, pos, state, level.getBlockEntity(pos), new ItemStack(Items.NETHERITE_PICKAXE));
-        level.destroyBlock(pos, true, entityTargetable.getTargetEntity(), (int) Math.round(strength));
+        level.destroyBlock(pos, false, entityTargetable.getTargetEntity(), (int) Math.round(strength));
       }
   }
   @Override


### PR DESCRIPTION
Fixes #37 

Issue was with serialization breaking valid tokens into multiple tokens over page lines. Tokens are now always preserved, either by moving the whole token to the next page, or by overfilling a page if necessary.