### PR TITLE
A PR to add four new gamerules and some vocal casting "fixes".

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
     outputs.file new File(output)
 
     dependsOn remapJar
-	/*
+	
     doLast {
       System.out.println("Signing jar...")
 
@@ -61,7 +61,7 @@ subprojects {
       ].execute()
       jarsigner.waitFor()
     }
-	*/
+	
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
     outputs.file new File(output)
 
     dependsOn remapJar
-
+	/*
     doLast {
       System.out.println("Signing jar...")
 
@@ -61,6 +61,7 @@ subprojects {
       ].execute()
       jarsigner.waitFor()
     }
+	*/
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
         // mappings "net.fabricmc:yarn:1.19.2+build.3:v2"
     }
 
-  tasks.register("signedJar") {
+   tasks.register("signedJar") {
     def output = buildDir.toPath()
             .resolve("libs")
             .resolve(remapJar.archiveFileName.get().replace(".jar", "-sgd.jar"))
@@ -32,7 +32,7 @@ subprojects {
     outputs.file new File(output)
 
     dependsOn remapJar
-
+	/*
     doLast {
       System.out.println("Signing jar...")
 
@@ -59,8 +59,8 @@ subprojects {
               input,
               alias
       ].execute()
-      jarsigner.waitFor()
-    }
+      jarsigner.waitFor() 
+   } */
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
         // mappings "net.fabricmc:yarn:1.19.2+build.3:v2"
     }
 
-   tasks.register("signedJar") {
+  tasks.register("signedJar") {
     def output = buildDir.toPath()
             .resolve("libs")
             .resolve(remapJar.archiveFileName.get().replace(".jar", "-sgd.jar"))
@@ -32,7 +32,7 @@ subprojects {
     outputs.file new File(output)
 
     dependsOn remapJar
-	/*
+
     doLast {
       System.out.println("Signing jar...")
 
@@ -59,8 +59,8 @@ subprojects {
               input,
               alias
       ].execute()
-      jarsigner.waitFor() 
-   } */
+      jarsigner.waitFor()
+    }
   }
 }
 

--- a/common/src/main/java/com/ssblur/scriptor/ScriptorGameRules.java
+++ b/common/src/main/java/com/ssblur/scriptor/ScriptorGameRules.java
@@ -13,6 +13,7 @@ public class ScriptorGameRules {
   public static Key<IntegerValue> VOCAL_DAMAGE_THRESHOLD;
   public static Key<IntegerValue> VOCAL_COOLDOWN_MULTIPLIER;
   public static Key<IntegerValue> TOME_COOLDOWN_MULTIPLIER;
+  public static Key<IntegerValue> CASTING_LECTERN_COOLDOWN_MULTIPLIER;	
 
   public static void register() {
     TOME_MAX_COST = GameRules.register("scriptor:tome_max_cost", Category.MISC, IntegerValue.create(50));
@@ -22,5 +23,6 @@ public class ScriptorGameRules {
     VOCAL_DAMAGE_THRESHOLD = GameRules.register("scriptor:vocal_damage_threshold", Category.MISC, IntegerValue.create(75));
     VOCAL_COOLDOWN_MULTIPLIER = GameRules.register("scriptor:vocal_cooldown_multiplier", Category.MISC, IntegerValue.create(100));
     TOME_COOLDOWN_MULTIPLIER = GameRules.register("scriptor:tome_cooldown_multiplier", Category.MISC, IntegerValue.create(100));
+    CASTING_LECTERN_COOLDOWN_MULTIPLIER = GameRules.register("scriptor:casting_lectern_cooldown_multiplier", Category.MISC, IntegerValue.create(100));
   }
 }

--- a/common/src/main/java/com/ssblur/scriptor/ScriptorGameRules.java
+++ b/common/src/main/java/com/ssblur/scriptor/ScriptorGameRules.java
@@ -20,7 +20,7 @@ public class ScriptorGameRules {
     TOME_MAX_COST = GameRules.register("scriptor:tome_max_cost", Category.MISC, IntegerValue.create(50));
     CHALK_MAX_COST = GameRules.register("scriptor:chalk_max_cost", Category.MISC, IntegerValue.create(200));
     VOCAL_MAX_COST = GameRules.register("scriptor:vocal_max_cost", Category.MISC, IntegerValue.create(-1));
-    VOCAL_MAX_COST = GameRules.register("scriptor:casting_lectern_max_cost", Category.MISC, IntegerValue.create(20));
+    CASTING_LECTERN_MAX_COST = GameRules.register("scriptor:casting_lectern_max_cost", Category.MISC, IntegerValue.create(20));
     VOCAL_HUNGER_THRESHOLD = GameRules.register("scriptor:vocal_hunger_threshold", Category.MISC, IntegerValue.create(50));
     VOCAL_DAMAGE_THRESHOLD = GameRules.register("scriptor:vocal_damage_threshold", Category.MISC, IntegerValue.create(75));
     VOCAL_COOLDOWN_MULTIPLIER = GameRules.register("scriptor:vocal_cooldown_multiplier", Category.MISC, IntegerValue.create(100));

--- a/common/src/main/java/com/ssblur/scriptor/ScriptorGameRules.java
+++ b/common/src/main/java/com/ssblur/scriptor/ScriptorGameRules.java
@@ -11,6 +11,8 @@ public class ScriptorGameRules {
   public static Key<IntegerValue> VOCAL_MAX_COST;
   public static Key<IntegerValue> VOCAL_HUNGER_THRESHOLD;
   public static Key<IntegerValue> VOCAL_DAMAGE_THRESHOLD;
+  public static Key<IntegerValue> VOCAL_COOLDOWN_MULTIPLIER;
+  public static Key<IntegerValue> TOME_COOLDOWN_MULTIPLIER;
 
   public static void register() {
     TOME_MAX_COST = GameRules.register("scriptor:tome_max_cost", Category.MISC, IntegerValue.create(50));
@@ -18,5 +20,7 @@ public class ScriptorGameRules {
     VOCAL_MAX_COST = GameRules.register("scriptor:vocal_max_cost", Category.MISC, IntegerValue.create(-1));
     VOCAL_HUNGER_THRESHOLD = GameRules.register("scriptor:vocal_hunger_threshold", Category.MISC, IntegerValue.create(50));
     VOCAL_DAMAGE_THRESHOLD = GameRules.register("scriptor:vocal_damage_threshold", Category.MISC, IntegerValue.create(75));
+    VOCAL_COOLDOWN_MULTIPLIER = GameRules.register("scriptor:vocal_cooldown_multiplier", Category.MISC, IntegerValue.create(100));
+    TOME_COOLDOWN_MULTIPLIER = GameRules.register("scriptor:tome_cooldown_multiplier", Category.MISC, IntegerValue.create(100));
   }
 }

--- a/common/src/main/java/com/ssblur/scriptor/ScriptorGameRules.java
+++ b/common/src/main/java/com/ssblur/scriptor/ScriptorGameRules.java
@@ -9,6 +9,7 @@ public class ScriptorGameRules {
   public static Key<IntegerValue> TOME_MAX_COST;
   public static Key<IntegerValue> CHALK_MAX_COST;
   public static Key<IntegerValue> VOCAL_MAX_COST;
+  public static Key<IntegerValue> CASTING_LECTERN_MAX_COST;
   public static Key<IntegerValue> VOCAL_HUNGER_THRESHOLD;
   public static Key<IntegerValue> VOCAL_DAMAGE_THRESHOLD;
   public static Key<IntegerValue> VOCAL_COOLDOWN_MULTIPLIER;
@@ -19,6 +20,7 @@ public class ScriptorGameRules {
     TOME_MAX_COST = GameRules.register("scriptor:tome_max_cost", Category.MISC, IntegerValue.create(50));
     CHALK_MAX_COST = GameRules.register("scriptor:chalk_max_cost", Category.MISC, IntegerValue.create(200));
     VOCAL_MAX_COST = GameRules.register("scriptor:vocal_max_cost", Category.MISC, IntegerValue.create(-1));
+    VOCAL_MAX_COST = GameRules.register("scriptor:casting_lectern_max_cost", Category.MISC, IntegerValue.create(20));
     VOCAL_HUNGER_THRESHOLD = GameRules.register("scriptor:vocal_hunger_threshold", Category.MISC, IntegerValue.create(50));
     VOCAL_DAMAGE_THRESHOLD = GameRules.register("scriptor:vocal_damage_threshold", Category.MISC, IntegerValue.create(75));
     VOCAL_COOLDOWN_MULTIPLIER = GameRules.register("scriptor:vocal_cooldown_multiplier", Category.MISC, IntegerValue.create(100));

--- a/common/src/main/java/com/ssblur/scriptor/blockentity/CastingLecternBlockEntity.java
+++ b/common/src/main/java/com/ssblur/scriptor/blockentity/CastingLecternBlockEntity.java
@@ -99,7 +99,7 @@ public class CastingLecternBlockEntity extends BlockEntity {
         var text = compound.getList("pages", Tag.TAG_STRING);
         Spell spell = DictionarySavedData.computeIfAbsent(server).parse(LimitedBookSerializer.decodeText(text));
         if(spell != null) {
-          if(spell.cost() > 20) {
+          if(spell.cost() > level.getGameRules().getInt(ScriptorGameRules.CASTING_LECTERN_MAX_COST)) {
             ParticleNetwork.fizzle(level, getBlockPos());
             level.playSound(null, this.getBlockPos(), SoundEvents.FIRE_EXTINGUISH, SoundSource.BLOCKS, 1.0F, level.getRandom().nextFloat() * 0.4F + 0.8F);
             cooldown += (int) Math.round(200.0D * ( (double) level.getGameRules().getInt(ScriptorGameRules.CASTING_LECTERN_COOLDOWN_MULTIPLIER) / (double) 100));

--- a/common/src/main/java/com/ssblur/scriptor/blockentity/CastingLecternBlockEntity.java
+++ b/common/src/main/java/com/ssblur/scriptor/blockentity/CastingLecternBlockEntity.java
@@ -1,5 +1,6 @@
 package com.ssblur.scriptor.blockentity;
 
+import com.ssblur.scriptor.ScriptorGameRules;
 import com.ssblur.scriptor.block.CastingLecternBlock;
 import com.ssblur.scriptor.data.DictionarySavedData;
 import com.ssblur.scriptor.events.network.ParticleNetwork;
@@ -101,7 +102,7 @@ public class CastingLecternBlockEntity extends BlockEntity {
           if(spell.cost() > 20) {
             ParticleNetwork.fizzle(level, getBlockPos());
             level.playSound(null, this.getBlockPos(), SoundEvents.FIRE_EXTINGUISH, SoundSource.BLOCKS, 1.0F, level.getRandom().nextFloat() * 0.4F + 0.8F);
-            cooldown += 200;
+            cooldown += (int) Math.round(200.0D * ( (double) level.getGameRules().getInt(ScriptorGameRules.CASTING_LECTERN_COOLDOWN_MULTIPLIER) / (double) 100));
             return;
           }
           var state = level.getBlockState(getBlockPos());
@@ -122,7 +123,7 @@ public class CastingLecternBlockEntity extends BlockEntity {
             }
           }
           spell.cast(target);
-          cooldown += (int) Math.round(spell.cost() * 10);
+          cooldown += (int) Math.round(spell.cost() * 10.0D * ( (double) level.getGameRules().getInt(ScriptorGameRules.CASTING_LECTERN_COOLDOWN_MULTIPLIER) / (double) 100));
         }
       }
     }

--- a/common/src/main/java/com/ssblur/scriptor/events/SpellChatEvents.java
+++ b/common/src/main/java/com/ssblur/scriptor/events/SpellChatEvents.java
@@ -39,7 +39,7 @@ public class SpellChatEvents implements ChatEvent.Received {
           if (level.getGameRules().getInt(ScriptorGameRules.VOCAL_MAX_COST) >= 0 && cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_MAX_COST))
             player.sendSystemMessage(Component.translatable("extra.scriptor.mute"));
 		
-		  double adjustedCost = (int) Math.round( (double)cost * ( (double) level.getGameRules().getInt(ScriptorGameRules.VOCAL_COOLDOWN_MULTIPLIER) / (double) 100 ) );
+		  int adjustedCost = (int) Math.round( (double)cost * ( (double) level.getGameRules().getInt(ScriptorGameRules.VOCAL_COOLDOWN_MULTIPLIER) / (double) 100 ) );
 		  if (!player.isCreative()) {
 			  player.addEffect(new MobEffectInstance(ScriptorEffects.HOARSE.get(), adjustedCost));
 			  if (adjustedCost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD))

--- a/common/src/main/java/com/ssblur/scriptor/events/SpellChatEvents.java
+++ b/common/src/main/java/com/ssblur/scriptor/events/SpellChatEvents.java
@@ -39,13 +39,13 @@ public class SpellChatEvents implements ChatEvent.Received {
           if (level.getGameRules().getInt(ScriptorGameRules.VOCAL_MAX_COST) >= 0 && cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_MAX_COST))
             player.sendSystemMessage(Component.translatable("extra.scriptor.mute"));
 		
-		  cost = (int) Math.round( (double)cost * ( (double) level.getGameRules().getInt(ScriptorGameRules.VOCAL_COOLDOWN_MULTIPLIER) / (double) 100 ) );
+		  double adjustedCost = (int) Math.round( (double)cost * ( (double) level.getGameRules().getInt(ScriptorGameRules.VOCAL_COOLDOWN_MULTIPLIER) / (double) 100 ) );
 		  if (!player.isCreative()) {
-			  player.addEffect(new MobEffectInstance(ScriptorEffects.HOARSE.get(), cost));
-			  if (cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD))
-				player.addEffect(new MobEffectInstance(MobEffects.HUNGER, 2*(cost - level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD))));
-			  if (cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_DAMAGE_THRESHOLD))
-				player.hurt(Objects.requireNonNull(ScriptorDamage.overload(player)), (cost - level.getGameRules().getInt(ScriptorGameRules.VOCAL_DAMAGE_THRESHOLD) * 0.75f) / 100f);
+			  player.addEffect(new MobEffectInstance(ScriptorEffects.HOARSE.get(), adjustedCost));
+			  if (adjustedCost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD))
+				player.addEffect(new MobEffectInstance(MobEffects.HUNGER, 2*(adjustedCost - level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD))));
+			  if (adjustedCost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_DAMAGE_THRESHOLD))
+				player.hurt(Objects.requireNonNull(ScriptorDamage.overload(player)), (adjustedCost - level.getGameRules().getInt(ScriptorGameRules.VOCAL_DAMAGE_THRESHOLD) * 0.75f) / 100f);
 		  }
           if(player.getHealth() > 0)
             spell.cast(new EntityTargetable(player));

--- a/common/src/main/java/com/ssblur/scriptor/events/SpellChatEvents.java
+++ b/common/src/main/java/com/ssblur/scriptor/events/SpellChatEvents.java
@@ -38,13 +38,15 @@ public class SpellChatEvents implements ChatEvent.Received {
 
           if (level.getGameRules().getInt(ScriptorGameRules.VOCAL_MAX_COST) >= 0 && cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_MAX_COST))
             player.sendSystemMessage(Component.translatable("extra.scriptor.mute"));
-
-          player.addEffect(new MobEffectInstance(ScriptorEffects.HOARSE.get(), cost));
-          if (cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD))
-            player.addEffect(new MobEffectInstance(MobEffects.HUNGER, level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD)));
-          if (cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_DAMAGE_THRESHOLD))
-            player.hurt(Objects.requireNonNull(ScriptorDamage.overload(player)), (cost - level.getGameRules().getInt(ScriptorGameRules.VOCAL_DAMAGE_THRESHOLD) * 0.75f) / 100f);
-
+		
+		  cost = (int) Math.round( (double)cost * ( (double) level.getGameRules().getInt(ScriptorGameRules.VOCAL_COOLDOWN_MULTIPLIER) / (double) 100 ) );
+		  if (!player.isCreative()) {
+			  player.addEffect(new MobEffectInstance(ScriptorEffects.HOARSE.get(), cost));
+			  if (cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD))
+				player.addEffect(new MobEffectInstance(MobEffects.HUNGER, 2*(cost - level.getGameRules().getInt(ScriptorGameRules.VOCAL_HUNGER_THRESHOLD))));
+			  if (cost > level.getGameRules().getInt(ScriptorGameRules.VOCAL_DAMAGE_THRESHOLD))
+				player.hurt(Objects.requireNonNull(ScriptorDamage.overload(player)), (cost - level.getGameRules().getInt(ScriptorGameRules.VOCAL_DAMAGE_THRESHOLD) * 0.75f) / 100f);
+		  }
           if(player.getHealth() > 0)
             spell.cast(new EntityTargetable(player));
 

--- a/common/src/main/java/com/ssblur/scriptor/helpers/SpellbookHelper.java
+++ b/common/src/main/java/com/ssblur/scriptor/helpers/SpellbookHelper.java
@@ -36,7 +36,7 @@ public class SpellbookHelper {
         player.sendSystemMessage(Component.translatable("extra.scriptor.fizzle"));
         ScriptorAdvancements.FIZZLE.get().trigger((ServerPlayer) player);
         if(!player.isCreative())
-          addCooldown(player, 350);
+          addCooldown(player, (int) Math.round( 350.0D * ( (double) level.getGameRules().getInt(ScriptorGameRules.TOME_COOLDOWN_MULTIPLIER) / (double) 100) ));
         return true;
       }
       spell.cast(new SpellbookTargetable(itemStack, player, player.getInventory().selected).withTargetItem(false));

--- a/common/src/main/java/com/ssblur/scriptor/helpers/SpellbookHelper.java
+++ b/common/src/main/java/com/ssblur/scriptor/helpers/SpellbookHelper.java
@@ -42,7 +42,7 @@ public class SpellbookHelper {
       spell.cast(new SpellbookTargetable(itemStack, player, player.getInventory().selected).withTargetItem(false));
       if(!player.isCreative()) {
 		double adjustedCost = spell.cost() * (double) ( (double) level.getGameRules().getInt(ScriptorGameRules.TOME_COOLDOWN_MULTIPLIER) / (double) 100);
-        addCooldown(player, (int) Math.round(adjustedcost * 7));
+        addCooldown(player, (int) Math.round(adjustedCost * 7));
 	  }
       return false;
     }

--- a/common/src/main/java/com/ssblur/scriptor/helpers/SpellbookHelper.java
+++ b/common/src/main/java/com/ssblur/scriptor/helpers/SpellbookHelper.java
@@ -40,8 +40,10 @@ public class SpellbookHelper {
         return true;
       }
       spell.cast(new SpellbookTargetable(itemStack, player, player.getInventory().selected).withTargetItem(false));
-      if(!player.isCreative())
-        addCooldown(player, (int) Math.round(spell.cost() * 7));
+      if(!player.isCreative()) {
+		double adjustedcost = spell.cost() * (double) ( (double) level.getGameRules().getInt(ScriptorGameRules.TOME_COOLDOWN_MULTIPLIER) / (double) 100);
+        addCooldown(player, (int) Math.round(adjustedcost * 7));
+	  }
       return false;
     }
     return true;

--- a/common/src/main/java/com/ssblur/scriptor/helpers/SpellbookHelper.java
+++ b/common/src/main/java/com/ssblur/scriptor/helpers/SpellbookHelper.java
@@ -41,7 +41,7 @@ public class SpellbookHelper {
       }
       spell.cast(new SpellbookTargetable(itemStack, player, player.getInventory().selected).withTargetItem(false));
       if(!player.isCreative()) {
-		double adjustedcost = spell.cost() * (double) ( (double) level.getGameRules().getInt(ScriptorGameRules.TOME_COOLDOWN_MULTIPLIER) / (double) 100);
+		double adjustedCost = spell.cost() * (double) ( (double) level.getGameRules().getInt(ScriptorGameRules.TOME_COOLDOWN_MULTIPLIER) / (double) 100);
         addCooldown(player, (int) Math.round(adjustedcost * 7));
 	  }
       return false;

--- a/common/src/main/resources/assets/scriptor/lang/en_us.json
+++ b/common/src/main/resources/assets/scriptor/lang/en_us.json
@@ -233,6 +233,8 @@
 
   "gamerule.scriptor:tome_max_cost": "[Scriptor] Tome Max Spell Cost",
   "gamerule.scriptor:vocal_max_cost": "[Scriptor] Vocal Max Spell Cost",
+  "gamerule.scriptor:chalk_max_cost": "[Scriptor] Chalk Max Spell Cost",
+  "gamerule.scriptor:casting_lectern_max_cost": "[Scriptor] Casting Lectern Max Spell Cost",
   "gamerule.scriptor:vocal_hunger_threshold": "[Scriptor] Min Cost For Hunger",
   "gamerule.scriptor:vocal_damage_threshold": "[Scriptor] Min Cost for Damage",
   "gamerule.scriptor:vocal_cooldown_multiplier": "[Scriptor] Vocal Cooldown Multiplier",

--- a/common/src/main/resources/assets/scriptor/lang/en_us.json
+++ b/common/src/main/resources/assets/scriptor/lang/en_us.json
@@ -235,6 +235,9 @@
   "gamerule.scriptor:vocal_max_cost": "[Scriptor] Vocal Max Spell Cost",
   "gamerule.scriptor:vocal_hunger_threshold": "[Scriptor] Min Cost For Hunger",
   "gamerule.scriptor:vocal_damage_threshold": "[Scriptor] Min Cost for Damage",
+  "gamerule.scriptor:vocal_cooldown_multiplier": "[Scriptor] Vocal Cooldown Multiplier",
+  "gamerule.scriptor:tome_cooldown_multiplier": "[Scriptor] Tome Cooldown Multiplier",
+  "gamerule.scriptor:casting_lectern_cooldown_multiplier": "[Scriptor] Casting Lectern Cooldown Multiplier",
 
   "tome.scriptor.big_ups": "Big Ups",
   "tome.scriptor.breathless": "Breathless",

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -7,7 +7,7 @@ architectury {
     platformSetupLoomIde()
     fabric()
 }
-
+/*
 modrinth {
     token = System.getenv("MODRINTH_TOKEN")
     projectId = "scriptor-magicae"
@@ -26,6 +26,7 @@ modrinth {
     syncBodyFrom = rootProject.file("README.md").text
 }
 tasks.modrinth.dependsOn tasks.named("signedJar")
+*/
 
 loom {
     accessWidenerPath = project(":common").loom.accessWidenerPath

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -7,7 +7,7 @@ architectury {
     platformSetupLoomIde()
     fabric()
 }
-/*
+
 modrinth {
     token = System.getenv("MODRINTH_TOKEN")
     projectId = "scriptor-magicae"
@@ -26,7 +26,7 @@ modrinth {
     syncBodyFrom = rootProject.file("README.md").text
 }
 tasks.modrinth.dependsOn tasks.named("signedJar")
-*/
+
 
 loom {
     accessWidenerPath = project(":common").loom.accessWidenerPath

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -7,7 +7,7 @@ architectury {
     platformSetupLoomIde()
     fabric()
 }
-/*
+
 modrinth {
     token = System.getenv("MODRINTH_TOKEN")
     projectId = "scriptor-magicae"
@@ -26,7 +26,6 @@ modrinth {
     syncBodyFrom = rootProject.file("README.md").text
 }
 tasks.modrinth.dependsOn tasks.named("signedJar")
-*/
 
 loom {
     accessWidenerPath = project(":common").loom.accessWidenerPath

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -8,7 +8,7 @@ architectury {
     forge()
 }
 
-/* modrinth {
+modrinth {
     token = System.getenv("MODRINTH_TOKEN")
     projectId = "scriptor-magicae"
     versionNumber = version
@@ -24,7 +24,7 @@ architectury {
     }
     syncBodyFrom = rootProject.file("README.md").text
 }
-tasks.modrinth.dependsOn tasks.named("signedJar") */
+tasks.modrinth.dependsOn tasks.named("signedJar")
 
 loom {
     accessWidenerPath = project(":common").loom.accessWidenerPath

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -8,7 +8,7 @@ architectury {
     forge()
 }
 
-modrinth {
+/* modrinth {
     token = System.getenv("MODRINTH_TOKEN")
     projectId = "scriptor-magicae"
     versionNumber = version
@@ -24,7 +24,7 @@ modrinth {
     }
     syncBodyFrom = rootProject.file("README.md").text
 }
-tasks.modrinth.dependsOn tasks.named("signedJar")
+tasks.modrinth.dependsOn tasks.named("signedJar") */
 
 loom {
     accessWidenerPath = project(":common").loom.accessWidenerPath


### PR DESCRIPTION
This PR adds four gamerules I wanted for customisability: Separate cooldown multipliers for vocal, tome, and casting lectern casting, plus a missing gamerule for casting lectern maximum cost.
These multipliers are independent of the maximum cost and are applied just before the cooldown/hunger/damage is applied to the player. 
Since gameRules only support integer or boolean values they are stored as percentages. 100 is 1x, 50 is 0.5x, 200 is 2x, etc.

It also changes vocal casting in these two ways which I consider to be fixes; The duration of the hunger effect is now twice the difference between the cost and the threshold in ticks, and the hoarseness/hunger/damage is now not applied when the player is in Creative mode.

I am not terribly familiar with Minecraft modding, but everything worked perfectly when I tested it.