### PR TITLE
fixes #151 (crafting recipe of the guide doesn't work)

### DIFF
--- a/common/src/main/resources/data/scriptor/recipe/patchouli_book.json
+++ b/common/src/main/resources/data/scriptor/recipe/patchouli_book.json
@@ -9,7 +9,10 @@
     }
   ],
   "result": {
-    "id": "scriptor:patchouli_book",
-    "count": 1
+    "components": {
+      "patchouli:book": "scriptor:scriptor_guide"
+    },
+    "count": 1,
+    "id": "patchouli:guide_book"
   }
 }


### PR DESCRIPTION
Unfortunately, Patchouli in newer versions don't seem to support the "patchouli:shapeless_book_recipe" type, which would be needed. Therefore, we have to create the components. I used the example in the code of patchouli as a template.