### PR TITLE
Add three tiers of MagicBlock toughness dependent on the Spell strength

### DIFF
--- a/common/src/main/kotlin/com/ssblur/scriptor/block/MagicBlock.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/block/MagicBlock.kt
@@ -6,13 +6,13 @@ import net.fabricmc.api.EnvType
 import net.fabricmc.api.Environment
 import net.minecraft.client.renderer.RenderType
 import net.minecraft.world.item.DyeColor
-import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.SoundType
+import net.minecraft.world.level.block.TransparentBlock
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument
 
-class MagicBlock(val color: DyeColor): Block(
+class MagicBlock(val color: DyeColor, val strength: Float): TransparentBlock(
   Properties.of().instrument(NoteBlockInstrument.HAT)
-    .strength(0.3f)
+    .strength(strength)
     .sound(SoundType.GLASS)
     .noOcclusion()
     .mapColor(color)

--- a/common/src/main/kotlin/com/ssblur/scriptor/block/ScriptorBlocks.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/block/ScriptorBlocks.kt
@@ -3,10 +3,13 @@ package com.ssblur.scriptor.block
 import com.ssblur.scriptor.ScriptorMod
 import com.ssblur.scriptor.item.ScriptorTabs
 import com.ssblur.unfocused.helper.ColorHelper
+import com.ssblur.unfocused.registry.RegistrySupplier
 import com.ssblur.unfocused.tab.CreativeTabs.tab
 import net.minecraft.tags.TagKey
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.state.BlockBehaviour
+
+val block_toughness = listOf(0.3f, 1.5f, 5f)
 
 object ScriptorBlocks {
   val DO_NOT_PHASE: TagKey<Block> = ScriptorMod.registerBlockTag("do_not_phase")
@@ -21,8 +24,15 @@ object ScriptorBlocks {
   val GENERATE = ScriptorMod.registerBlock("generate") { GenerateBlock() }
   val HIGHLIGHT_MODEL = ScriptorMod.registerBlock("highlight_model") { HighlightBlock(BlockBehaviour.Properties.of()) }
 
-  val MAGIC_BLOCKS = ColorHelper.forEachColor {
-    ScriptorMod.registerBlock(it.nameAllLowerCase + "_magic_block") { MagicBlock(it.dyeColor) }
+//  Lists of coloured magic blocks, one for each toughness/opacity combination. These lists must be separate to support
+//  the DyeColorableBlock 'setColor' method
+  val MAGIC_BLOCKS_LISTS: List<List<RegistrySupplier<Block>>> = block_toughness.mapIndexed { index, toughness ->
+    ColorHelper.forEachColor {
+      val id = it.nameAllLowerCase + "_magic_block_toughness_" + index
+      ScriptorMod.registerBlock(id) {
+        MagicBlock(color=it.dyeColor, strength=toughness)
+      }
+    }
   }
 
   fun register() {

--- a/common/src/main/kotlin/com/ssblur/scriptor/registry/colorable/DyeColorableBlocks.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/registry/colorable/DyeColorableBlocks.kt
@@ -18,7 +18,7 @@ object DyeColorableBlocks {
   val CANDLE = DyeColorableBlock()
   val BED = DyeColorableBlock()
   val SHULKER_BOX = DyeColorableBlock()
-  val MAGIC_BLOCK = DyeColorableBlock()
+  val COLOURABLE_MAGIC_BLOCK_LISTS: List<DyeColorableBlock> = ScriptorBlocks.MAGIC_BLOCKS_LISTS.map{DyeColorableBlock()}
 
   init {
     WOOL.add(Blocks.BLACK_WOOL, DyeColor.BLACK)
@@ -219,11 +219,13 @@ object DyeColorableBlocks {
     CONCRETE.add(Blocks.YELLOW_CONCRETE, DyeColor.YELLOW)
     CONCRETE.register()
 
-    ScriptorBlocks.MAGIC_BLOCKS.forEach {
-      val magicBlock = it.get()
-      if (magicBlock is MagicBlock)
-        MAGIC_BLOCK.add(magicBlock, magicBlock.color)
+    ScriptorBlocks.MAGIC_BLOCKS_LISTS.forEachIndexed {
+      index, magicBlockList -> magicBlockList.forEach{
+        val magicBlock = it.get()
+        if (magicBlock is MagicBlock)
+          COLOURABLE_MAGIC_BLOCK_LISTS[index].add(magicBlock, magicBlock.color)
+      }
+      COLOURABLE_MAGIC_BLOCK_LISTS[index].register()
     }
-    MAGIC_BLOCK.register()
   }
 }

--- a/common/src/main/kotlin/com/ssblur/scriptor/word/action/PlaceBlockAction.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/word/action/PlaceBlockAction.kt
@@ -8,6 +8,7 @@ import com.ssblur.scriptor.helpers.targetable.Targetable
 import com.ssblur.scriptor.mixin.BlockPlaceContextAccessor
 import com.ssblur.scriptor.network.client.ParticleNetwork
 import com.ssblur.scriptor.registry.colorable.ColorableBlockRegistry.DYE_COLORABLE_BLOCKS
+import com.ssblur.scriptor.word.descriptor.power.StrengthDescriptor
 import net.minecraft.world.InteractionHand
 import net.minecraft.world.InteractionResult
 import net.minecraft.world.item.BlockItem
@@ -18,8 +19,13 @@ class PlaceBlockAction: Action() {
 
   override fun apply(caster: Targetable, targetable: Targetable, descriptors: Array<Descriptor>) {
     val color = getColor(descriptors)
+    var strength = 1.0
+    for (d in descriptors) {
+      if (d is StrengthDescriptor) strength += d.strengthModifier()
+    }
     val pos = targetable.targetBlockPos
     val level = targetable.level
+
 
     if (!level.getBlockState(pos).canBeReplaced()) return
 
@@ -40,7 +46,11 @@ class PlaceBlockAction: Action() {
       )
       if (!status.consumesAction()) ParticleNetwork.fizzle(level, targetable.targetBlockPos)
     } else {
-      DYE_COLORABLE_BLOCKS.MAGIC_BLOCK.setColor(color, level, pos)
+      when {
+        strength < 2.0 -> DYE_COLORABLE_BLOCKS.COLOURABLE_MAGIC_BLOCK_LISTS[0].setColor(color, level, pos)
+        strength < 5.0 -> DYE_COLORABLE_BLOCKS.COLOURABLE_MAGIC_BLOCK_LISTS[1].setColor(color, level, pos)
+        else -> DYE_COLORABLE_BLOCKS.COLOURABLE_MAGIC_BLOCK_LISTS[2].setColor(color, level, pos)
+      }
     }
   }
 }

--- a/common/src/main/resources/assets/scriptor/blockstates/black_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/black_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/black_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/black_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/black_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/black_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/black_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/black_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/black_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/black_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/black_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/black_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/blue_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/blue_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/blue_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/blue_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/blue_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/blue_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/blue_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/blue_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/blue_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/blue_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/blue_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/blue_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/brown_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/brown_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/brown_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/brown_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/brown_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/brown_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/brown_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/brown_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/brown_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/brown_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/brown_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/brown_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/cyan_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/cyan_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/cyan_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/cyan_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/cyan_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/cyan_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/cyan_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/cyan_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/cyan_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/cyan_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/cyan_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/cyan_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/gray_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/gray_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/gray_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/gray_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/gray_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/gray_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/gray_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/gray_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/gray_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/gray_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/gray_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/gray_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/green_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/green_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/green_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/green_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/green_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/green_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/green_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/green_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/green_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/green_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/green_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/green_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/light_blue_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/light_blue_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/light_blue_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/light_blue_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/light_blue_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/light_blue_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/light_blue_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/light_blue_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/light_blue_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/light_blue_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/light_blue_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/light_blue_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/light_gray_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/light_gray_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/light_gray_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/light_gray_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/light_gray_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/light_gray_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/light_gray_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/light_gray_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/light_gray_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/light_gray_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/light_gray_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/light_gray_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/lime_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/lime_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/lime_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/lime_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/lime_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/lime_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/lime_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/lime_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/lime_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/lime_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/lime_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/lime_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/magenta_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/magenta_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/magenta_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/magenta_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/magenta_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/magenta_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/magenta_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/magenta_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/magenta_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/magenta_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/magenta_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/magenta_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/orange_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/orange_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/orange_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/orange_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/orange_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/orange_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/orange_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/orange_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/orange_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/orange_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/orange_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/orange_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/pink_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/pink_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/pink_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/pink_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/pink_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/pink_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/pink_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/pink_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/pink_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/pink_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/pink_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/pink_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/purple_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/purple_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/purple_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/purple_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/purple_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/purple_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/purple_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/purple_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/purple_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/purple_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/purple_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/purple_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/red_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/red_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/red_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/red_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/red_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/red_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/red_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/red_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/red_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/red_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/red_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/red_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/white_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/white_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/white_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/white_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/white_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/white_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/white_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/white_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/white_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/white_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/white_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/white_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/yellow_magic_block.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/yellow_magic_block.json
@@ -1,7 +1,0 @@
-{
-  "variants": {
-    "": {
-      "model": "scriptor:block/yellow_magic_block"
-    }
-  }
-}

--- a/common/src/main/resources/assets/scriptor/blockstates/yellow_magic_block_toughness_0.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/yellow_magic_block_toughness_0.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/yellow_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/yellow_magic_block_toughness_1.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/yellow_magic_block_toughness_1.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/yellow_magic_block"
+        }
+    }
+}

--- a/common/src/main/resources/assets/scriptor/blockstates/yellow_magic_block_toughness_2.json
+++ b/common/src/main/resources/assets/scriptor/blockstates/yellow_magic_block_toughness_2.json
@@ -1,0 +1,7 @@
+{
+    "variants": {
+        "": {
+            "model": "scriptor:block/yellow_magic_block"
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ssblur/scriptor/issues/180

Note: This will delete any existing MagicBlocks in players' worlds due to the change to ids and blockstates file names

Done:

    Added three strength-based tiers for MagicBlock, each increasing toughness and blast resistance.
    MagicBlock now inherits from TransparentBlock, which makes adjacent MagicBlocks appear 'merged'

Things I'd like to do, but haven't been able to figure out:

    Change opacity of block (seems to be binary, instead of sliding scale)
    Use one block and change the tinting/colour (can probably be done with geckolib, but seems excessive to add this lib for one feature)

Things I'm too lazy to do rn:

    Make 'reinforced' looking textures for higher tiers of block toughness

