### PR TITLE
Reset descriptor list after adding PartialSpell when parsing Spells

### DIFF
--- a/common/src/main/kotlin/com/ssblur/scriptor/data/saved_data/DictionarySavedData.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/data/saved_data/DictionarySavedData.kt
@@ -200,6 +200,8 @@ class DictionarySavedData: SavedData {
           if (parsed != null && parsed == "other:and") {
             tokenPosition++
             spells.add(PartialSpell(action!!, *descriptors.toTypedArray()))
+//          Reset descriptors list to allow precise control over which descriptors affect which action
+            descriptors.clear()
           } else {
             return null
           }


### PR DESCRIPTION
Closes https://github.com/ssblur/scriptor/issues/182

Gives players ability to make more complex spells, also nerfs 'and' word so may need cost re-balancing