### PR TITLE
Add new Square descriptor and method for transforming targets relative to player perspective

### DIFF
--- a/common/src/main/kotlin/com/ssblur/scriptor/helpers/MathHelper.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/helpers/MathHelper.kt
@@ -1,6 +1,12 @@
 package com.ssblur.scriptor.helpers
 
+import com.ssblur.scriptor.helpers.targetable.Targetable
+import net.minecraft.core.Direction
 import net.minecraft.world.phys.Vec2
+import net.minecraft.world.phys.Vec3
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.math.cos
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.pow
@@ -38,5 +44,98 @@ object MathHelper {
       }
     }
     return Vec2(x.toFloat(), y.toFloat())
+  }
+  /**
+   * Calculate the number of blocks required to form the square's border
+   * @param d: The diameter of the square
+   * @return the integer number of blocks required to form the square's border
+   */
+  fun calculate_square_border_length(d: Int): Int {
+    when(d) {
+      0 -> return 0
+      1 -> return 1
+    }
+    return (d*d) - ((d-2)*(d-2))
+  }
+  /**
+   * Returns a set of 2d coordinates forming the perimiter of a square
+   * @param diameter: The diameter of the square
+   * @return A set of Vec2 coordinates forming the perimiter of a square
+   */
+  fun get_square_coords(diameter: Int): ArrayList<Vec2> {
+//    Expect minimum 2x2 diameter square.
+    assert(diameter > 1)
+    var positions: ArrayList<Vec2> = arrayListOf<Vec2>()
+    val borderLength = calculate_square_border_length(diameter)
+    var pos: Pair<Float, Float>
+    for (i in 1..borderLength) {
+      when (i) {
+        0 -> pos = Pair(1f, 0f)
+        in 1..diameter -> pos = Pair(0f, (i-1).toFloat())
+        in diameter+1..diameter*2 - 1 -> pos = Pair((i-diameter).toFloat(), (diameter-1).toFloat())
+        in diameter*2..diameter*3 - 2 -> pos = Pair((diameter-1).toFloat(), (3*diameter-2-(i)).toFloat())
+        else -> pos = Pair((4*diameter-(3+i)).toFloat(), 0f)
+      }
+      positions.add(Vec2(pos.first, pos.second))
+    }
+
+    return positions
+  }
+  /**
+   * Rotates a point anticlockwise (in minecraft this seems to rotate clockwise)
+   * @param point: The Vec2 point to rotate
+   * @param degrees: The angle by which to rotate the point (degrees)
+   * @return The Vec2 point rotated by degrees
+   */
+  fun rotate_point_anticlockwise(point: Vec2, degrees: Float): Vec2 {
+    val radians = (degrees * (PI / 180f)).toFloat()
+    return Vec2(
+      point.x * cos(radians) - point.y * sin(radians),
+      point.x * sin(radians) + point.y * cos(radians),
+    )
+  }
+  /**
+   * Transforms a point according to the player's horizontal view direction (North, East, South, West)
+   * and the targeted face of the initial block target. This has the effect of affecting points relative
+   * to the player's perspective, rather than the absolute coordinate system
+   * @param initial_targetable: The first position targeted.
+   * @param owner: The player casting the spell.
+   * @param point: The point to transform according to player perspective
+   * @return The transformed Vec3 point
+   */
+  fun player_view_transform_point(initial_targetable: Targetable, owner: Targetable, point: Vec2): Vec3 {
+
+    val pos = initial_targetable.targetPos
+    val axis = initial_targetable.facing.axis
+
+    var newPos: Vec3
+    if (axis === Direction.Axis.X) {
+      var x_mult = if (owner.entityYRotation!!.toInt() in 180..360) {
+        1
+      } else {
+        -1
+      }
+      newPos = Vec3(
+        pos.x,
+        pos.y + point.y,
+        pos.z + point.x * x_mult
+      )
+    } else if (axis === Direction.Axis.Y) {
+      var transformed_point = rotate_point_anticlockwise(point, owner.entityCoarseYRotation!! + 90)
+      newPos = Vec3(
+        pos.x + transformed_point.x,
+        pos.y,
+        pos.z + transformed_point.y
+      )
+    }
+    else {
+      var x_mult = if (owner.entityYRotation!!.toInt() in 90..270) {
+        1
+      } else {
+        -1
+      }
+      newPos = Vec3(pos.x + point.x * x_mult, pos.y + point.y, pos.z)
+    }
+    return newPos
   }
 }

--- a/common/src/main/kotlin/com/ssblur/scriptor/helpers/MathHelper.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/helpers/MathHelper.kt
@@ -5,11 +5,13 @@ import net.minecraft.core.Direction
 import net.minecraft.world.phys.Vec2
 import net.minecraft.world.phys.Vec3
 import kotlin.math.PI
+import kotlin.math.abs
 import kotlin.math.sin
 import kotlin.math.cos
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.pow
+import kotlin.math.round
 import kotlin.math.sqrt
 
 object MathHelper {
@@ -44,6 +46,23 @@ object MathHelper {
       }
     }
     return Vec2(x.toFloat(), y.toFloat())
+  }
+  fun get_circle_coords(radius: Int): List<Vec2> {
+    assert(radius > 0)
+    var positions: ArrayList<Vec2> = arrayListOf<Vec2>()
+    var pos: Vec2
+    var mirror_pos: Vec2
+    for (i in 0..radius) {
+      pos = Vec2(i.toFloat(), round(sqrt((radius*radius).toFloat() - i*i)))
+      mirror_pos = Vec2(pos.x*-1, pos.y)
+      positions.add(pos)
+      positions.add(mirror_pos)
+      for (j in 1..3) {
+        positions.add(rotate_point_anticlockwise(pos, (90 * j).toFloat()))
+        positions.add(rotate_point_anticlockwise(mirror_pos, (90 * j).toFloat()))
+      }
+    }
+    return positions.map{ Vec2(it.x, it.y) }
   }
   /**
    * Calculate the number of blocks required to form the square's border

--- a/common/src/main/kotlin/com/ssblur/scriptor/helpers/targetable/EntityTargetable.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/helpers/targetable/EntityTargetable.kt
@@ -2,4 +2,18 @@ package com.ssblur.scriptor.helpers.targetable
 
 import net.minecraft.world.entity.Entity
 
-open class EntityTargetable(var targetEntity: Entity): Targetable(targetEntity.level(), targetEntity.position())
+open class EntityTargetable(var targetEntity: Entity): Targetable(targetEntity.level(), targetEntity.position()) {
+    override val entityYRotation: Float? = if (targetEntity.getYRot() > 0) {
+        targetEntity.getYRot()
+    } else {
+        targetEntity.getYRot() + 360
+    }
+
+    override val entityCoarseYRotation: Float? = when (entityYRotation!!.toInt()) {
+        in 0..45 -> 0f // South
+        in 315..360 -> 0f // South
+        in 45..135 -> 90f // East
+        in 135..225 -> 180f // North
+        else -> 270f // West
+    }
+}

--- a/common/src/main/kotlin/com/ssblur/scriptor/helpers/targetable/Targetable.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/helpers/targetable/Targetable.kt
@@ -48,6 +48,10 @@ open class Targetable {
       return Direction.UP
     }
 
+  open val entityYRotation: Float? = null
+
+  open val entityCoarseYRotation: Float? = null
+
   fun setFacing(direction: Direction?): Targetable {
     this.direction = direction
     return this

--- a/common/src/main/kotlin/com/ssblur/scriptor/registry/words/Descriptors.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/registry/words/Descriptors.kt
@@ -6,6 +6,7 @@ import com.ssblur.scriptor.word.descriptor.duration.SimpleDurationDescriptor
 import com.ssblur.scriptor.word.descriptor.target.ChainDescriptor
 import com.ssblur.scriptor.word.descriptor.target.CollideWithWaterDescriptor
 import com.ssblur.scriptor.word.descriptor.target.NetherDescriptor
+import com.ssblur.scriptor.word.descriptor.target.SquareDescriptor
 
 @Suppress("unused")
 object Descriptors {
@@ -37,6 +38,7 @@ object Descriptors {
     SpeedDurationDescriptor(2, -4.0, 1.25)
   )
   val CHAIN = register("chain", ChainDescriptor())
+  val SQUARE = register("square", SquareDescriptor())
 
   val NETHER = register("nether", NetherDescriptor())
   val COLLIDE_WITH_WATER = register("collide_with_water", CollideWithWaterDescriptor)

--- a/common/src/main/kotlin/com/ssblur/scriptor/registry/words/Descriptors.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/registry/words/Descriptors.kt
@@ -4,6 +4,7 @@ import com.ssblur.scriptor.registry.words.WordRegistry.register
 import com.ssblur.scriptor.word.descriptor.SpeedDurationDescriptor
 import com.ssblur.scriptor.word.descriptor.duration.SimpleDurationDescriptor
 import com.ssblur.scriptor.word.descriptor.target.ChainDescriptor
+import com.ssblur.scriptor.word.descriptor.target.CircleDescriptor
 import com.ssblur.scriptor.word.descriptor.target.CollideWithWaterDescriptor
 import com.ssblur.scriptor.word.descriptor.target.NetherDescriptor
 import com.ssblur.scriptor.word.descriptor.target.SquareDescriptor
@@ -39,6 +40,7 @@ object Descriptors {
   )
   val CHAIN = register("chain", ChainDescriptor())
   val SQUARE = register("square", SquareDescriptor())
+  val CIRCLE = register("circle", CircleDescriptor())
 
   val NETHER = register("nether", NetherDescriptor())
   val COLLIDE_WITH_WATER = register("collide_with_water", CollideWithWaterDescriptor)

--- a/common/src/main/kotlin/com/ssblur/scriptor/word/Spell.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/word/Spell.kt
@@ -13,6 +13,7 @@ import com.ssblur.scriptor.network.client.ParticleNetwork
 import com.ssblur.scriptor.word.descriptor.AfterCastDescriptor
 import com.ssblur.scriptor.word.descriptor.CastDescriptor
 import com.ssblur.scriptor.word.descriptor.focus.FocusDescriptor
+import com.ssblur.scriptor.word.descriptor.target.GeometricTargetDescriptor
 import com.ssblur.scriptor.word.descriptor.target.TargetDescriptor
 import net.minecraft.network.chat.Component
 import net.minecraft.server.level.ServerPlayer
@@ -35,8 +36,10 @@ class Spell(val subject: Subject, vararg val spells: PartialSpell) {
     for (spell in spells) {
       var caster = originalCaster
       var targets = originalTargets
-      for (descriptor in spell.deduplicatedDescriptors()) {
+      var deduplicatedDescriptors = spell.deduplicatedDescriptors()
+      for (descriptor in deduplicatedDescriptors) {
         if (descriptor is TargetDescriptor) targets = descriptor.modifyTargets(targets, caster)
+        if (descriptor is GeometricTargetDescriptor) targets = descriptor.modifyTargets(targets, caster, deduplicatedDescriptors)
         if (descriptor is FocusDescriptor) caster = descriptor.modifyFocus(caster)
       }
       for (target in targets)

--- a/common/src/main/kotlin/com/ssblur/scriptor/word/descriptor/target/CircleDescriptor.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/word/descriptor/target/CircleDescriptor.kt
@@ -1,0 +1,39 @@
+package com.ssblur.scriptor.word.descriptor.target
+
+import com.ssblur.scriptor.api.word.Descriptor
+import com.ssblur.scriptor.helpers.MathHelper
+import com.ssblur.scriptor.helpers.targetable.Targetable
+import net.minecraft.core.Direction
+import net.minecraft.world.phys.Vec2
+
+class CircleDescriptor: Descriptor(), GeometricTargetDescriptor {
+  override fun modifyTargets(originalTargetables: List<Targetable>, owner: Targetable, descriptors: Array<Descriptor>): List<Targetable> {
+    val targetables = originalTargetables.toMutableList()
+    val uses = descriptors.map{ it is CircleDescriptor }.count{ it }
+    if (targetables.isEmpty()) return targetables
+    val radius = uses
+    val circle_points = MathHelper.get_circle_coords(radius)
+    val targetable = targetables[0]
+    val axis = targetable.facing.axis
+
+    for (point in circle_points) {
+      //    Translate positions so initial coordinate is in top center. This allows placing empty circles without the center
+      //    point being filled in
+      var translated_point = if (axis === Direction.Axis.Y) {
+        Vec2(point.x + radius, point.y)
+      } else {
+        Vec2(point.x, point.y + radius)
+      }
+      var transformed_point = MathHelper.player_view_transform_point(targetable, owner, translated_point)
+      targetables.add(Targetable(targetable.level, transformed_point).setFacing(targetable.facing))
+    }
+
+    return targetables
+
+  }
+
+  override fun replacesSubjectCost() = false
+  override fun allowsDuplicates() = true
+  override fun cost() = Cost(1.25, COSTTYPE.MULTIPLICATIVE)
+
+}

--- a/common/src/main/kotlin/com/ssblur/scriptor/word/descriptor/target/GeometricTargetDescriptor.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/word/descriptor/target/GeometricTargetDescriptor.kt
@@ -1,0 +1,11 @@
+package com.ssblur.scriptor.word.descriptor.target
+
+import com.ssblur.scriptor.api.word.Descriptor
+import com.ssblur.scriptor.helpers.targetable.Targetable
+
+
+interface GeometricTargetDescriptor {
+//    Pass in list of descriptors to allow counting the number of specific descriptors
+    fun modifyTargets(originalTargetables: List<Targetable>, owner: Targetable, descriptors: Array<Descriptor>): List<Targetable>
+    fun replacesSubjectCost(): Boolean
+}

--- a/common/src/main/kotlin/com/ssblur/scriptor/word/descriptor/target/SquareDescriptor.kt
+++ b/common/src/main/kotlin/com/ssblur/scriptor/word/descriptor/target/SquareDescriptor.kt
@@ -1,0 +1,29 @@
+package com.ssblur.scriptor.word.descriptor.target
+
+import com.ssblur.scriptor.api.word.Descriptor
+import com.ssblur.scriptor.helpers.MathHelper
+import com.ssblur.scriptor.helpers.targetable.Targetable
+
+class SquareDescriptor: Descriptor(), GeometricTargetDescriptor {
+  override fun modifyTargets(originalTargetables: List<Targetable>, owner: Targetable, descriptors: Array<Descriptor>): List<Targetable> {
+    val targetables = originalTargetables.toMutableList()
+    val uses = descriptors.map{ it is SquareDescriptor }.count{ it }
+    if (targetables.isEmpty()) return targetables
+
+    val square_points = MathHelper.get_square_coords(uses+1)
+    val targetable = targetables[0]
+
+    for (point in square_points) {
+      var transformed_point = MathHelper.player_view_transform_point(targetable, owner, point)
+      targetables.add(Targetable(targetable.level, transformed_point).setFacing(targetable.facing))
+    }
+
+    return targetables
+
+  }
+
+  override fun replacesSubjectCost() = false
+  override fun allowsDuplicates() = true
+  override fun cost() = Cost(1.25, COSTTYPE.MULTIPLICATIVE)
+
+}

--- a/common/src/main/resources/assets/scriptor/lang/en_us.json
+++ b/common/src/main/resources/assets/scriptor/lang/en_us.json
@@ -179,6 +179,8 @@
   "descriptor.scriptor.move_up": "This spell's targets are moved one block up",
   "descriptor.scriptor.move_down": "This spell's targets are moved one block down",
   "descriptor.scriptor.collide_with_water": "This spell can be cast on fluids",
+  "descriptor.scriptor.circle": "This spell casts in a circle",
+  "descriptor.scriptor.square": "This spell casts in a square",
   "action.scriptor.inflame": "This spell heats or sets the target on fire.",
   "action.scriptor.light": "This spell places a light where it is cast.",
   "action.scriptor.heal": "This spell heals or repairs the target.",

--- a/common/src/main/resources/assets/scriptor/lang/en_us.json
+++ b/common/src/main/resources/assets/scriptor/lang/en_us.json
@@ -361,6 +361,8 @@
   "tome.scriptor.cheap_trick": "A Cheap Trick",
   "tome.scriptor.power_overwhelming": "Touch of Death",
   "tome.scriptor.growth": "Green Thumb",
+  "tome.scriptor.druid_circle": "Druidic Circle",
+  "tome.scriptor.frame": "Frame",
   "tome.scriptor.big_mistake": "Out of Touch",
   "tome.scriptor.wall_walker": "Portable Hole",
   "tome.scriptor.death_save": "Death Save",

--- a/common/src/main/resources/data/scriptor/scriptor/tomes/tier3/druid_circle.json
+++ b/common/src/main/resources/data/scriptor/scriptor/tomes/tier3/druid_circle.json
@@ -1,0 +1,18 @@
+{
+  "name": "tome.scriptor.druid_circle",
+  "author": "AnoubuzThuf",
+  "tier": 3,
+  "item": "scriptor:spellbook_lime",
+  "spell": {
+    "subject": "touch",
+    "spells": [
+      {
+        "action": "strength",
+        "descriptors": [
+          "circle",
+          "circle"
+        ]
+      }
+    ]
+  }
+}

--- a/common/src/main/resources/data/scriptor/scriptor/tomes/tier3/frame.json
+++ b/common/src/main/resources/data/scriptor/scriptor/tomes/tier3/frame.json
@@ -1,0 +1,19 @@
+{
+  "name": "tome.scriptor.frame",
+  "author": "AnoubuzThuf",
+  "tier": 3,
+  "item": "scriptor:spellbook_brown",
+  "spell": {
+    "subject": "touch",
+    "spells": [
+      {
+        "action": "place",
+        "descriptors": [
+          "square",
+          "square",
+          "brown"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added:
* GeometricTargetDescriptor for descriptors which have different behaviour depending on the other descriptors used in the current SubSpell. Intended for Geometric shapes (Square, Circle...) with increasing radius depending on the number of repetitions.
* Add Square Descriptor implementing GeometricTargetDescriptor
* Add Circle Descriptor implementing GeometricTargetDescriptor
* Add MathHelper function for transforming targets relative to player perspective - this is really cool!

TODO is:
* Adding examples of these as spellbooks

Note:
* I've only tested this on NeoForge